### PR TITLE
Add VAD capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The idea is:
 ```
 pacmd load-module module-null-sink sink_name=mic_denoised_out  
 
-pacmd load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so
+pacmd load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=50
 
 pacmd load-module module-loopback source=your_mic_name sink=mic_raw_in channels=1
 ```
@@ -43,7 +43,7 @@ This should be executed every time pulse audio is launched. This can be done by 
 .include /etc/pulse/default.pa
 
 load-module module-null-sink sink_name=mic_denoised_out  
-load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so
+load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=50
 load-module module-loopback source=your_mic_name sink=mic_raw_in channels=1
 
 set-default-source mic_denoised_out.monitor
@@ -66,6 +66,15 @@ pacmd list-sources
 ```
 
 You may still need to set correct input for application, this can be done in audio mixer panel (if you have one) in 'Recording' tab where you should set 'Monitor of Null Output' as source.
+
+Plugin settings:
+
+- VAD Threshold (%) - if probability of sound being a voice is lower than this threshold - silence will be returned.
+
+By default VAD threshold is 50% which should work with any mic. For most mics higher threshold `control=95` would be fine.
+Without the VAD some loud noises may still be a little bit audible when there is no voice.
+
+There is also an implicit grace period of 200 milliseconds, meaning that after the last voice detection - output won't be silenced for 200 ms.
 
 Useful detailed info about pulseaudio logic [toadjaune/pulseaudio-config](https://github.com/toadjaune/pulseaudio-config).
 

--- a/src/common/include/common/RnNoiseCommonPlugin.h
+++ b/src/common/include/common/RnNoiseCommonPlugin.h
@@ -12,7 +12,7 @@ public:
 
     void deinit();
 
-    void process(const float *in, float *out, int32_t sampleFrames);
+    void process(const float *in, float *out, int32_t sampleFrames, float vadThreshold);
 
 private:
 
@@ -22,9 +22,16 @@ private:
     static const int k_denoiseFrameSize = 480;
     static const int k_denoiseSampleRate = 48000;
 
+    /**
+     * The amount of samples that aren't silenced, regardless of rnnoise's VAD result, after one was detected.
+     * This fixes cut outs in the middle of words.
+     * Each sample is 10ms.
+     */
+    static const short k_vadGracePeriodSamples = 20;
+
     std::shared_ptr<DenoiseState> m_denoiseState;
 
-    short m_remaining_grace_period = 0;
+    short m_remainingGracePeriod = 0;
 
     std::vector<float> m_inputBuffer;
     std::vector<float> m_outputBuffer;

--- a/src/common/include/common/RnNoiseCommonPlugin.h
+++ b/src/common/include/common/RnNoiseCommonPlugin.h
@@ -24,6 +24,8 @@ private:
 
     std::shared_ptr<DenoiseState> m_denoiseState;
 
+    short m_remaining_grace_period = 0;
+
     std::vector<float> m_inputBuffer;
     std::vector<float> m_outputBuffer;
 };

--- a/src/lv2_plugin/RnNoiseLv2Plugin.cpp
+++ b/src/lv2_plugin/RnNoiseLv2Plugin.cpp
@@ -39,7 +39,7 @@ void RnNoiseLv2Plugin::run(uint32_t sample_count) {
     PluginBase::run(sample_count);
 
     if (m_inPort != nullptr && m_outPort != nullptr) {
-        m_rnNoisePlugin->process(m_inPort, m_outPort, sample_count);
+        m_rnNoisePlugin->process(m_inPort, m_outPort, sample_count, 0);
     }
 }
 

--- a/src/vst_plugin/RnNoiseVstPlugin.cpp
+++ b/src/vst_plugin/RnNoiseVstPlugin.cpp
@@ -21,7 +21,7 @@ void RnNoiseVstPlugin::processReplacing(float **inputs, float **outputs, VstInt3
     float *inChannel0 = inputs[0];
     float *outChannel0 = outputs[0];
 
-    m_rnNoisePlugin->process(inChannel0, outChannel0, sampleFrames);
+    m_rnNoisePlugin->process(inChannel0, outChannel0, sampleFrames, 0);
 }
 
 VstInt32 RnNoiseVstPlugin::startProcess() {


### PR DESCRIPTION
rnnoise can return the probability of a chunk being voice when processed. We can use this probability to define a threshold under which we return silence, giving us VAD (Voice Activity Detection) capabilities. This is an intended usecase of rnnoise.

I've been using this patch for a while for my VOIPing and it works great. [@werman asked me to open a PR](https://github.com/lawl/noise-suppression-for-voice/commit/b5285c99e71b22621e44fb8663281a5aa535d79a#commitcomment-38907690), which I've indeed been holding off for too long.

The issue here is that currently [the threshold for which to activate the VAD is hardcoded](https://github.com/werman/noise-suppression-for-voice/commit/b5285c99e71b22621e44fb8663281a5aa535d79a#diff-2273b50706164dcaa056998485954592R10). From my (limited) testing this cannot be shipped with a hard-coded value. The worse the microphone, the less certain rnnoise is that a sample is speech, and thus the threshold needs to be lowered.

As per commit message in b5285c9 

> Currently this threshold is hardcoded in a #define. The different plugins (LADSPA, VST, LV2) will need to be expanded with the respective configuration APIs and then this value can be passed to the CommonPlugin.

However, I'm currently not interested in implementing this, so I'm opening this as a draft-PR, to see if anyone is interested in making this configurable and shippable, or discuss if there's another way to ship this.

Side note, there's another constant [`VAD_GRACE_PERIOD`](https://github.com/werman/noise-suppression-for-voice/commit/b533222d49c7f83ae35ecee4c9e5e9fff65b7050#diff-2273b50706164dcaa056998485954592R15) that I think is fine to just hard-code and doesn't need to be configurable.