### PR TITLE
Fix CMake Project Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+project("Real-time Noise Suppression Plugin")
 cmake_minimum_required(VERSION 3.6)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
This patch is mostly cosmetic. It fixes the warning appearing when you run Cmake it which it complains that no top-level
project statement is present:

    CMake Warning (dev) in CMakeLists.txt:
      No project() command is present.  The top-level CMakeLists.txt file must
      contain a literal, direct call to the project() command.  Add a line of
      code such as

        project(ProjectName)

      near the top of the file, but after cmake_minimum_required().

      CMake is pretending there is a "project(Project)" command on the first
      line.
    This warning is for project developers.  Use -Wno-dev to suppress it.