### PR TITLE
Ecasound instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ Further reading:
 - Useful detailed info about PulseAudio logic [toadjaune/pulseaudio-config](https://github.com/toadjaune/pulseaudio-config).
 - The [thread](https://bugs.freedesktop.org/show_bug.cgi?id=101043) which helped me with how to post-process mic output and make it available to applications.
 
+#### Ecasound
+
+[Ecasound](https://ecasound.seul.org/ecasound/) is a software package designed for multitrack auto processing and makes it easy to chain together processing blocks. Packages are available for most distributions.
+
+You may need to make sure that the LADSPA plugin is copied to the correct directory for your distribution. Check the plugin has been registered with:
+
+```echo "ladspa-register" | ecasound -c
+```
+
+If the noise_suppressor_mono and noise_supressor_stereo plugins are not visible, ensure its directory is in the plugin path:
+
+```export LADSPA_PATH=$LADSPA_PATH:/path_to_ladspa.so
+```
+
+To process a file:
+
+```ecasound -i infile.wav -o outfile.wav -el:noise_suppressor_stereo,n
+```
+
+Where n is the VAD threshold as described above.
+
+To process in realtime using the ASLA default input and output devices (e.g. a USB sound card):
+
+```ecasound -i alsa -o alsa -el:noise_suppressor_stereo,n
+```
+
+A small device such as a Raspberry Pi model B can easily process a stereo signal in realtime. The plugin can be compiled on the device using the x64 instructions below.
+
 ### MacOS
 
 You will need to compile library yourself following steps below.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ You may need to make sure that the LADSPA plugin is copied to the correct direct
 ```echo "ladspa-register" | ecasound -c
 ```
 
-```sh
-pacmd load-module module-remap-source source_name=denoised master=mic_denoised_out.monitor channels=1
+```echo "ladspa-register" | ecasound -c
 ```
 
 If the noise_suppressor_mono and noise_supressor_stereo plugins are not visible, ensure its directory is in the plugin path:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Further reading:
 - Useful detailed info about PulseAudio logic [toadjaune/pulseaudio-config](https://github.com/toadjaune/pulseaudio-config).
 - The [thread](https://bugs.freedesktop.org/show_bug.cgi?id=101043) which helped me with how to post-process mic output and make it available to applications.
 
+
 #### Ecasound
 
 [Ecasound](https://ecasound.seul.org/ecasound/) is a software package designed for multitrack auto processing and makes it easy to chain together processing blocks. Packages are available for most distributions.
@@ -113,6 +114,7 @@ To process in realtime using the ASLA default input and output devices (e.g. a U
 ```
 
 A small device such as a Raspberry Pi model B can easily process a stereo signal in realtime. The plugin can be compiled on the device using the x64 instructions below.
+
 
 ### MacOS
 

--- a/README.md
+++ b/README.md
@@ -90,27 +90,32 @@ Further reading:
 
 You may need to make sure that the LADSPA plugin is copied to the correct directory for your distribution. Check the plugin has been registered with:
 
-```echo "ladspa-register" | ecasound -c
+```sh
+echo "ladspa-register" | ecasound -c
 ```
 
-```echo "ladspa-register" | ecasound -c
+```sh
+echo "ladspa-register" | ecasound -c
 ```
 
 If the noise_suppressor_mono and noise_supressor_stereo plugins are not visible, ensure its directory is in the plugin path:
 
-```export LADSPA_PATH=$LADSPA_PATH:/path_to_ladspa.so
+```sh
+export LADSPA_PATH=$LADSPA_PATH:/path_to_ladspa.so
 ```
 
 To process a file:
 
-```ecasound -i infile.wav -o outfile.wav -el:noise_suppressor_stereo,n
+```sh
+ecasound -i infile.wav -o outfile.wav -el:noise_suppressor_stereo,n
 ```
 
 Where n is the VAD threshold as described above.
 
 To process in realtime using the ASLA default input and output devices (e.g. a USB sound card):
 
-```ecasound -i alsa -o alsa -el:noise_suppressor_stereo,n
+```sh
+ecasound -i alsa -o alsa -el:noise_suppressor_stereo,n
 ```
 
 A small device such as a Raspberry Pi model B can easily process a stereo signal in realtime. The plugin can be compiled on the device using the x64 instructions below.

--- a/README.md
+++ b/README.md
@@ -94,14 +94,10 @@ You may need to make sure that the LADSPA plugin is copied to the correct direct
 echo "ladspa-register" | ecasound -c
 ```
 
-```sh
-echo "ladspa-register" | ecasound -c
-```
-
-If the noise_suppressor_mono and noise_supressor_stereo plugins are not visible, ensure its directory is in the plugin path:
+If the noise_suppressor_mono and noise_supressor_stereo plugins are not shown, ensure its directory is in the plugin path:
 
 ```sh
-export LADSPA_PATH=$LADSPA_PATH:/path_to_ladspa.so
+export LADSPA_PATH=$LADSPA_PATH:/path_to_librnnoise_ladspa.so
 ```
 
 To process a file:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ You may need to make sure that the LADSPA plugin is copied to the correct direct
 ```echo "ladspa-register" | ecasound -c
 ```
 
+```sh
+pacmd load-module module-remap-source source_name=denoised master=mic_denoised_out.monitor channels=1
+```
+
 If the noise_suppressor_mono and noise_supressor_stereo plugins are not visible, ensure its directory is in the plugin path:
 
 ```export LADSPA_PATH=$LADSPA_PATH:/path_to_ladspa.so


### PR DESCRIPTION
I discovered that the Ecasound package is a simple way to use the plugin for processing files offline. I was also able to use it as in "insert" device in a mixing desk to denoise radio microphones by compiling it on a Raspberry PI and using Ecasound to route from the default ALSA input device, via the plugin, to the default ALSA output device - in this case a USB audio interface. 