### PR TITLE
Potential fix for crackling and audio issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ If you have a stereo input use these options instead:
 - `label=noise_suppressor_stereo`
 - `channels=2`
 
+If you have problems with audio crackling or high / periodically increasing latency, adding `latency_msec=1` to the loopback might help:
+```
+load-module module-loopback source=your_mic_name sink=mic_raw_in channels=1 source_dont_move=true sink_dont_move=true latency_msec=1
+```
+
 :warning: Chrome and other Chromium based browsers will ignore monitor devices and you will not be able to select the "Monitor of Null Output".
 To work around this, either use pavucontrol to assign the input to Chrome, or remap this device in PulseAudio to create a regular source:
 


### PR DESCRIPTION
While setting this up, I had problems with latency. The longer I had the noise suppression module loaded, the more input latency appeared on the sink. After about an hour it was up to two seconds.

I found a hint to use `latency_msec=1` in https://github.com/werman/noise-suppression-for-voice/issues/70#issuecomment-798642967. It was suggested against crackling, but it also helped against the increasing latency for me. I also had crackling for some reconnects of the microphone. Both problems went away with this option. It might be a good idea to add that to the README as this PR does, if you agree that this solution makes sense.