### PR TITLE
Add some `=` signs to the PipeWire config snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ context.modules = [
                     plugin = /path/to/librnnoise_ladspa.so
                     label = noise_suppressor_mono
                     control = {
-                        "VAD Threshold (%)" 50.0
-                        "VAD Grace Period (ms)" 200
-                        "Retroactive VAD Grace (ms)" 0
+                        "VAD Threshold (%)" = 50.0
+                        "VAD Grace Period (ms)" = 200
+                        "Retroactive VAD Grace (ms)" = 0
                     }
                 }
             ]


### PR DESCRIPTION
https://docs.pipewire.org/page_module_filter_chain.html says that the equal signs are supposed to be present there:

![image](https://user-images.githubusercontent.com/308347/197771869-c0d3ad3b-c2ed-45ac-a9f0-0c31ed619a4b.png)

But for some reason PipeWire seems to load the plugin without complaining. I haven't checked whether the parameters were actually used. I haven't checked the new format either, besides verifying that the plugin gets loaded and the source is present.