### PR TITLE
CMake: Fix cmake_minimum_required() call location warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project("Real-time Noise Suppression Plugin")
 cmake_minimum_required(VERSION 3.6)
+project("Real-time Noise Suppression Plugin")
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
```
=> noise-suppression-for-voice-1.03-r0: running do_configure...
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```