### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/external/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
+++ b/external/JUCE/modules/juce_audio_formats/codecs/flac/libFLAC/bitreader.c
@@ -830,7 +830,7 @@ incomplete_lsbs:
 			cwords = br->consumed_words;
 			words = br->words;
 			ucbits = FLAC__BITS_PER_WORD - br->consumed_bits;
-			b = br->buffer[cwords] << br->consumed_bits;
+			b = cwords < br->capacity ? br->buffer[cwords] << br->consumed_bits : 0;
 		} while(cwords >= words && val < end);
 	}
 


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in FLAC__bitreader_read_rice_signed_block() that was cloned from flac but did not receive the security patch. The original issue was reported and fixed under https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-0499
https://github.com/xiph/flac/commit/2e7931c27eb15e387da440a37f12437e35b22dd4
