### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/external/JUCE/modules/juce_core/zip/zlib/crc32.c
+++ b/external/JUCE/modules/juce_core/zip/zlib/crc32.c
@@ -287,7 +287,7 @@ local unsigned long crc32_little(unsigned long crc, const unsigned char FAR *buf
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = (u4) (crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
                   crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24])
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
@@ -306,7 +306,6 @@ local unsigned long crc32_big (unsigned long crc, const unsigned char FAR *buf, 
     }
 
     buf4 = (const u4 FAR *)(const void FAR *)buf;
-    buf4--;
     while (len >= 32) {
         DOBIG32;
         len -= 32;
@@ -315,7 +314,6 @@ local unsigned long crc32_big (unsigned long crc, const unsigned char FAR *buf, 
         DOBIG4;
         len -= 4;
     }
-    buf4++;
     buf = (const unsigned char FAR *)buf4;
 
     if (len) do {


### PR DESCRIPTION
Description
This PR fixes a security vulnerability in crc32_big() that was cloned from zlib but did not receive the security patch. The original issue was reported and fixed under https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2016-9843
https://github.com/madler/zlib/commit/d1d577490c15a0c6862473d7576352a9f18ef811