### PR TITLE
New Feature: Dry/Wet Control

### DIFF
--- a/src/common/include/common/RnNoiseCommonPlugin.h
+++ b/src/common/include/common/RnNoiseCommonPlugin.h
@@ -18,6 +18,10 @@ struct RnNoiseStats {
     /* How many blocks are in an output queue in a single channel. Represents current latency. */
     uint32_t blocksWaitingForOutput;
 
+    /* Exact number of frames currently queued in the output (includes partial block).
+     * This is the precise sample latency at the start of a processing call. */
+    uint64_t samplesWaitingForOutput;
+
     /* How many output frames we are forced to zero out because there is not enough frames to write. */
     uint64_t outputFramesForcedToBeZeroed;
 };

--- a/src/common/src/RnNoiseCommonPlugin.cpp
+++ b/src/common/src/RnNoiseCommonPlugin.cpp
@@ -176,6 +176,7 @@ RnNoiseCommonPlugin::process(const float *const *in, float **out, size_t sampleF
     }
 
     bool hasEnoughFrames = !m_channels[0].rnnoiseOutput.empty();
+    size_t queuedFramesAtStart = 0;
     if (hasEnoughFrames)
     {
         int32_t blockIdxRelative = static_cast<int32_t>(m_newOutputIdx - m_currentOutputIdxToOutput) - 1;
@@ -184,6 +185,7 @@ RnNoiseCommonPlugin::process(const float *const *in, float **out, size_t sampleF
         size_t firstBlockFrames =
                 k_denoiseBlockSize - m_channels[0].rnnoiseOutput.rbegin()[blockIdxRelative]->curOffset;
         size_t totalFrames = blockIdxRelative * k_denoiseBlockSize + firstBlockFrames;
+        queuedFramesAtStart = totalFrames;
         hasEnoughFrames = totalFrames >= (sampleFrames + k_denoiseBlockSize * retroactiveVADGraceBlocks);
     }
 
@@ -197,9 +199,14 @@ RnNoiseCommonPlugin::process(const float *const *in, float **out, size_t sampleF
 
         stats.outputFramesForcedToBeZeroed += sampleFrames;
         stats.blocksWaitingForOutput = 0;
+        stats.samplesWaitingForOutput = 0;
         m_stats.store(stats);
         return;
     }
+
+    // Report exact queued frames at the start of this copy step as the precise latency in samples
+    stats.samplesWaitingForOutput = queuedFramesAtStart;
+    m_stats.store(stats);
 
     uint64_t newOutputIdxToOutput = 0;
     for (auto &channel: m_channels) {

--- a/src/juce_plugin/RnNoiseAudioProcessor.cpp
+++ b/src/juce_plugin/RnNoiseAudioProcessor.cpp
@@ -24,12 +24,18 @@ RnNoiseAudioProcessor::RnNoiseAudioProcessor()
                                                                   "Retroactive VAD Grace Period (10ms per unit)",
                                                                   0,
                                                                   10,
-                                                                  0)
+                                                                  0),
+                        std::make_unique<juce::AudioParameterFloat>("dry_wet",
+                                                                    "Dry/Wet",
+                                                                    0.0f,
+                                                                    1.0f,
+                                                                    1.0f)
                 }) {
     m_vadThresholdParam = (juce::AudioParameterFloat *) m_parameters.getParameter("vad_threshold");
     m_vadGracePeriodParam = (juce::AudioParameterInt *) m_parameters.getParameter("vad_grace_period");
     m_vadRetroactiveGracePeriodParam = (juce::AudioParameterInt *) m_parameters.getParameter(
             "vad_retroactive_grace_period");
+    m_dryWetParam = (juce::AudioParameterFloat *) m_parameters.getParameter("dry_wet");
 }
 
 RnNoiseAudioProcessor::~RnNoiseAudioProcessor() = default;
@@ -79,6 +85,20 @@ void RnNoiseAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock
 
     m_rnNoisePlugin = std::make_shared<RnNoiseCommonPlugin>(static_cast<uint32_t>(getTotalNumInputChannels()));
     m_rnNoisePlugin->init();
+
+    // Initialize dry delay buffers per channel
+    const int channels = getTotalNumInputChannels();
+    m_dryDelayBuffers.clear();
+    m_dryDelayWritePos.clear();
+    m_dryDelayFilled.clear();
+    m_dryDelayBuffers.resize(channels);
+    m_dryDelayWritePos.resize(channels, 0);
+    m_dryDelayFilled.resize(channels, 0);
+    // default capacity: 50 blocks (~500ms) to start; will grow if needed
+    m_dryDelayCapacity = 480 * 50;
+    for (int ch = 0; ch < channels; ++ch) {
+        m_dryDelayBuffers[ch].assign(m_dryDelayCapacity, 0.0f);
+    }
 }
 
 void RnNoiseAudioProcessor::releaseResources() {
@@ -115,16 +135,76 @@ void RnNoiseAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
         buffer.clear(i, 0, buffer.getNumSamples());
 
+    const int numSamples = buffer.getNumSamples();
+
+    // Copy dry input before it is overwritten by wet processing
+    std::vector<std::vector<float>> dryInput(totalNumInputChannels, std::vector<float>(numSamples, 0.0f));
+    for (int ch = 0; ch < totalNumInputChannels; ++ch) {
+        const float* src = buffer.getReadPointer(ch);
+        std::copy(src, src + numSamples, dryInput[ch].begin());
+    }
+
     const float *in[8] = {nullptr};
     float *out[8] = {nullptr};
     for (int channel = 0; channel < totalNumInputChannels; ++channel) {
-        in[channel] = buffer.getReadPointer(channel);
+        in[channel] = dryInput[channel].data();
         out[channel] = buffer.getWritePointer(channel);
     }
 
-    m_rnNoisePlugin->process(in, out, static_cast<size_t>(buffer.getNumSamples()), m_vadThresholdParam->get(),
+    m_rnNoisePlugin->process(in, out, static_cast<size_t>(numSamples), m_vadThresholdParam->get(),
                              static_cast<uint32_t>(m_vadGracePeriodParam->get()),
                              static_cast<uint32_t>(m_vadRetroactiveGracePeriodParam->get()));
+
+    // Determine wet latency precisely in samples
+    size_t delaySamples = 0;
+    if (m_rnNoisePlugin) {
+        RnNoiseStats stats = m_rnNoisePlugin->getStats();
+        if (stats.samplesWaitingForOutput > 0) {
+            delaySamples = static_cast<size_t>(stats.samplesWaitingForOutput);
+        } else {
+            delaySamples = static_cast<size_t>(stats.blocksWaitingForOutput) * 480u;
+        }
+    }
+
+    // Ensure dry delay buffers have enough capacity; grow if necessary
+    if (delaySamples + static_cast<size_t>(numSamples) > m_dryDelayCapacity) {
+        size_t newCap = delaySamples + static_cast<size_t>(numSamples) + 480u; // add a block of headroom
+        m_dryDelayCapacity = newCap;
+        for (int ch = 0; ch < totalNumInputChannels; ++ch) {
+            m_dryDelayBuffers[ch].assign(m_dryDelayCapacity, 0.0f);
+            m_dryDelayWritePos[ch] = 0;
+            m_dryDelayFilled[ch] = 0;
+        }
+    }
+
+    const float wetMix = m_dryWetParam ? m_dryWetParam->get() : 1.0f;
+    const float dryMix = 1.0f - wetMix;
+
+    // Mix dry (delayed) and wet into buffer
+    for (int ch = 0; ch < totalNumInputChannels; ++ch) {
+        float* wet = buffer.getWritePointer(ch);
+        auto& ring = m_dryDelayBuffers[ch];
+        size_t& wpos = m_dryDelayWritePos[ch];
+        size_t& filled = m_dryDelayFilled[ch];
+        const auto& inDry = dryInput[ch];
+
+        for (int i = 0; i < numSamples; ++i) {
+            float delayedDry;
+            if (delaySamples == 0) {
+                delayedDry = inDry[i];
+            } else {
+                size_t readIndex = (wpos + m_dryDelayCapacity - (delaySamples % m_dryDelayCapacity)) % m_dryDelayCapacity;
+                delayedDry = (filled >= delaySamples) ? ring[readIndex] : 0.0f;
+            }
+
+            // write current dry sample into ring
+            ring[wpos] = inDry[i];
+            wpos = (wpos + 1) % m_dryDelayCapacity;
+            if (filled < m_dryDelayCapacity) ++filled;
+
+            wet[i] = wet[i] * wetMix + delayedDry * dryMix;
+        }
+    }
 }
 
 //==============================================================================

--- a/src/juce_plugin/RnNoiseAudioProcessor.h
+++ b/src/juce_plugin/RnNoiseAudioProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <vector>
 
 class RnNoiseCommonPlugin;
 
@@ -51,8 +52,15 @@ public:
     juce::AudioParameterFloat* m_vadThresholdParam;
     juce::AudioParameterInt* m_vadGracePeriodParam;
     juce::AudioParameterInt* m_vadRetroactiveGracePeriodParam;
+    juce::AudioParameterFloat* m_dryWetParam;
 
     std::shared_ptr<RnNoiseCommonPlugin> m_rnNoisePlugin;
+
+    // Dry path delay to align with wet path latency for proper Dry/Wet mix
+    std::vector<std::vector<float>> m_dryDelayBuffers;   // per-channel circular buffers
+    std::vector<size_t> m_dryDelayWritePos;              // per-channel write indices
+    std::vector<size_t> m_dryDelayFilled;                // per-channel filled sample counts (up to capacity)
+    size_t m_dryDelayCapacity = 0;                       // capacity per channel
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (RnNoiseAudioProcessor)
 };

--- a/src/juce_plugin/RnNoisePluginEditor.cpp
+++ b/src/juce_plugin/RnNoisePluginEditor.cpp
@@ -18,6 +18,7 @@ RnNoiseAudioProcessorEditor::RnNoiseAudioProcessorEditor(RnNoiseAudioProcessor &
     auto vadThresholdParam = m_processorRef.m_parameters.getParameter("vad_threshold");
     auto vadGracePeriodParam = m_processorRef.m_parameters.getParameter("vad_grace_period");
     auto vadRetroactiveGracePeriodParam = m_processorRef.m_parameters.getParameter("vad_retroactive_grace_period");
+    auto dryWetParam = m_processorRef.m_parameters.getParameter("dry_wet");
 
     m_vadThresholdLabel.setText(vadThresholdParam->getName(99), juce::dontSendNotification);
     addAndMakeVisible(m_vadThresholdLabel);
@@ -40,6 +41,13 @@ RnNoiseAudioProcessorEditor::RnNoiseAudioProcessorEditor(RnNoiseAudioProcessor &
     m_vadRetroactiveGracePeriodAttachment = std::make_unique<SliderAttachment>(m_valueTreeState,
                                                                                vadRetroactiveGracePeriodParam->getParameterID(),
                                                                                m_vadRetroactiveGracePeriodSlider);
+
+    m_dryWetLabel.setText(dryWetParam->getName(99), juce::dontSendNotification);
+    addAndMakeVisible(m_dryWetLabel);
+    addAndMakeVisible(m_dryWetSlider);
+    m_dryWetAttachment = std::make_unique<SliderAttachment>(m_valueTreeState,
+                                                            dryWetParam->getParameterID(),
+                                                            m_dryWetSlider);
 
     addAndMakeVisible(m_statsHeaderLabel);
     m_statsHeaderLabel.setText("Debug Statistics (updated once per second)", juce::dontSendNotification);
@@ -77,6 +85,9 @@ void RnNoiseAudioProcessorEditor::resized() {
             juce::FlexItem(m_vadRetroactiveGracePeriodLabel).withWidth(width).withFlex(1.0));
     flexBox.items.add(
             juce::FlexItem(m_vadRetroactiveGracePeriodSlider).withWidth(width).withFlex(1.0));
+
+    flexBox.items.add(juce::FlexItem(m_dryWetLabel).withWidth(width).withFlex(1.0));
+    flexBox.items.add(juce::FlexItem(m_dryWetSlider).withWidth(width).withFlex(1.0));
 
     flexBox.items.add(
             juce::FlexItem(m_statsHeaderLabel).withWidth(width).withFlex(1.0));

--- a/src/juce_plugin/RnNoisePluginEditor.h
+++ b/src/juce_plugin/RnNoisePluginEditor.h
@@ -37,6 +37,10 @@ private:
     juce::Slider m_vadRetroactiveGracePeriodSlider;
     std::unique_ptr<SliderAttachment> m_vadRetroactiveGracePeriodAttachment;
 
+    juce::Label m_dryWetLabel;
+    juce::Slider m_dryWetSlider;
+    std::unique_ptr<SliderAttachment> m_dryWetAttachment;
+
     juce::Label m_statsHeaderLabel;
     juce::Label m_statsVadGraceBlocksLabel;
     juce::Label m_statsRetroactiveVadGraceBlocksLabel;


### PR DESCRIPTION
Adds a Dry/Wet mix with UI control.

The dry audio signal is sample-accurately synced to the latency of the wet signal, so they can blend without phasing artifacts.

— Implementation —
- `src/common/include/common/RnNoiseCommonPlugin.h` and `src/common/src/RnNoiseCommonPlugin.cpp`:
  - Extend `RnNoiseStats` with `samplesWaitingForOutput` (exact queued frames at the start of processing).
- `src/juce_plugin/RnNoiseAudioProcessor.*`:
  - Add Dry/Wet parameter (APVTS).
  - In `processBlock()`, read precise wet latency and delay the dry path via per‑channel ring buffers before mixing; fallback to `blocksWaitingForOutput * 480` if needed.
    - Rationale: using block-rounded latency can cause phase mismatch when host buffers aren’t multiples of 480. Sample-accurate alignment avoids this issue.
- `src/juce_plugin/RnNoisePluginEditor.*`:
  - Add Dry/Wet slider to the UI.

<img width="430" height="453" alt="rnnoise-ui-preview" src="https://github.com/user-attachments/assets/92505fe3-46c3-4c9c-94a9-d4f0bc52091e" />