### PR TITLE
Fix batch: docs, build optimisations, dry/wet mix, LADSPA ports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-project("Real-time Noise Suppression Plugin")
 cmake_minimum_required(VERSION 3.6)
+# Let project() manage VERSION variables (CMP0048)
+if(POLICY CMP0048)
+    cmake_policy(SET CMP0048 NEW)
+endif()
+project("Real-time Noise Suppression Plugin" VERSION 1.99 LANGUAGES C CXX)
 
 include(GNUInstallDirs)
 
@@ -10,12 +14,13 @@ set(CMAKE_BINARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(MINGW_ADDITIONAL_LINKING_FLAGS "-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread -Wl,-Bdynamic")
 
 if(NOT BUILD_VERSION)
-    set(BUILD_VERSION 1.99)
+    set(BUILD_VERSION ${PROJECT_VERSION})
 endif()
 
 option(USE_SYSTEM_JUCE "" OFF)
 option(BUILD_FOR_RELEASE "Additional optimizations and steps may be taken for release" OFF)
 option(BUILD_TESTS "" ON)
+option(ENABLE_NATIVE_OPTIMIZATIONS "Use -O3, -march=native and SIMD for Release builds (GCC/Clang)" ON)
 option(BUILD_VST_PLUGIN "If the VST2 plugin should be built" ON)
 option(BUILD_VST3_PLUGIN "If the VST3 plugin should be built" ON)
 option(BUILD_LV2_PLUGIN "If the LV2 plugin should be built" ON)
@@ -23,6 +28,16 @@ option(BUILD_LADSPA_PLUGIN "If the LADSPA plugin should be built" ON)
 option(BUILD_AU_PLUGIN "If the AU plugin should be built (macOS only)" ON)
 option(BUILD_AUV3_PLUGIN "If the AUv3 plugin should be built (macOS only)" ON)
 option(BUILD_RTCD "Enable x86 run-time CPU detection (x86 only)" OFF)
+
+# Release build optimisations: -O3, -march=native, and optional SIMD (SSE2/AVX) when enabled
+if(ENABLE_NATIVE_OPTIMIZATIONS AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -march=native")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -march=native")
+    # SSE2/AVX are typically implied by -march=native on x86; explicit flags for clarity where needed
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86|i686|AMD64|x86_64")
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -msse2")
+    endif()
+endif()
 
 if (BUILD_TESTS)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/external/catch2/)
@@ -38,6 +53,9 @@ if (BUILD_VST_PLUGIN OR BUILD_VST3_PLUGIN OR BUILD_LV2_PLUGIN OR BUILD_AU_PLUGIN
     if (USE_SYSTEM_JUCE)
         find_package(JUCE)
     else ()
+        if(NOT JUCE_SOURCE_DIR)
+            set(JUCE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/JUCE CACHE PATH "Path to JUCE source (e.g. for JUCE 7.0.6+)")
+        endif()
         # For install JUCE copies all its headers, no one needs them. It also doesn't install actual libraries.
         # On the other hand JUCE could install libraries during build process (see COPY_PLUGIN_AFTER_BUILD option).
         # So we have to manually install plugins.

--- a/README.md
+++ b/README.md
@@ -40,20 +40,26 @@ There is a minimalistic GUI with all parameters and diagnostic stats:
 ### Plugin Settings
 
 - `VAD Threshold (%)` - if probability of sound being a voice is lower than this threshold - it will be silenced.
-  In most cases the threshold between 85% - 95% would be fine.
+  Valid range: 0–100%. Recommended default: **85%**; in most cases 85%–95% works well.
   Without the VAD some loud noises may still be a bit audible when there is no voice.
 - `VAD Grace Period (ms)` - for how long after the last voice detection the output won't be silenced. This helps when ends of words/sentences are being cut off.
 - `Retroactive VAD Grace Period (ms)` - similar to `VAD Grace Period (ms)` but for starts of words/sentences. :warning: This introduces latency!
+- `Mix` (0–100% or 0–1 in some hosts) - dry/wet blend. 100% (1.0) = fully processed (wet); 0% = dry only.
 
 ### Windows + Equalizer APO (VST2)
 
-To check or change mic settings go to "Recording devices" -> "Recording" -> "Properties" of the target mic -> "Advanced".
+**Download Equalizer APO:** [equalizerapo.com](https://equalizerapo.com/) or [SourceForge](https://sourceforge.net/projects/equalizerapo/). Equalizer APO is an open-source system-wide equalizer for Windows that supports VST plugins.
 
-To enable the plugin in Equalizer APO select "Plugins" -> "VST Plugin" and specify the plugin dll.
+**Installation steps (Windows 10/11):**
 
-See [detailed guide](https://medium.com/@bssankaran/free-and-open-source-software-noise-cancelling-for-working-from-home-edb1b4e9764e) provided by  [@bssankaran](https://github.com/bssankaran).
+1. Download and run the Equalizer APO installer from [equalizerapo.com](https://equalizerapo.com/).
+2. During setup, choose the audio device(s) you want to process (e.g. your microphone). You can change mic settings later via **Settings → System → Sound → Recording** (or right‑click the speaker icon → Sound settings → Recording), then **Properties** of the target mic → **Advanced**.
+3. Reboot when the installer prompts you.
+4. After reboot, open **Equalizer APO Configuration** (from Start or the installer folder).
+5. To add this plugin: **Plugins → VST Plugin** and point to the RNNoise plugin DLL (e.g. `rnnoise_mono.dll` or `rnnoise_stereo.dll` from the build output).
+6. The plugin has a GUI; you can adjust VAD threshold, grace periods, and mix there.
 
-- v1.0: Now there is a GUI, so it became easy to change parameters. 
+See also the [detailed guide](https://medium.com/@bssankaran/free-and-open-source-software-noise-cancelling-for-working-from-home-edb1b4e9764e) by [@bssankaran](https://github.com/bssankaran). 
 
 ### Linux
 
@@ -82,7 +88,7 @@ context.modules = [
                     plugin = /path/to/librnnoise_ladspa.so
                     label = noise_suppressor_mono
                     control = {
-                        "VAD Threshold (%)" = 50.0
+                        "VAD Threshold (%)" = 85.0
                         "VAD Grace Period (ms)" = 200
                         "Retroactive VAD Grace (ms)" = 0
                     }
@@ -140,7 +146,7 @@ pactl list sources short
 Then, create the new device using:
 ```sh
 pacmd load-module module-null-sink sink_name=mic_denoised_out rate=48000
-pacmd load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=50,20,0,0,0
+pacmd load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=85,20,0,85,1
 pacmd load-module module-loopback source=<your_mic_name> sink=mic_raw_in channels=1 source_dont_move=true sink_dont_move=true
 ```
 
@@ -151,13 +157,13 @@ You can automate this by creating file in `~/.config/pulse/default.pa` with the 
 .include /etc/pulse/default.pa
 
 load-module module-null-sink sink_name=mic_denoised_out rate=48000
-load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=50,200,0,0,0
+load-module module-ladspa-sink sink_name=mic_raw_in sink_master=mic_denoised_out label=noise_suppressor_mono plugin=/path/to/librnnoise_ladspa.so control=85,200,0,85,1
 load-module module-loopback source=your_mic_name sink=mic_raw_in channels=1 source_dont_move=true sink_dont_move=true
 
 set-default-source mic_denoised_out.monitor
 ```
 
-The order of settings in `control=50,200,0,0,0` is: `VAD Threshold (%)`, `VAD Grace Period (ms)`, `Retroactive VAD Grace Period (ms)`, `Placeholder1`, `Placeholder2`.
+The order of settings in `control=85,200,0,85,1` is: `VAD Threshold (%)`, `VAD Grace Period (ms)`, `Retroactive VAD Grace Period (ms)`, `VAD Threshold (port)`, `Mix` (0–1, 1 = full wet). Recommended default for VAD Threshold: 85%.
 
 If you are absolutely sure that you want a stereo input use these options instead:
 
@@ -185,9 +191,19 @@ Further reading:
 
 </details>
 
-### MacOS
+### macOS
 
-TODO, contributions are welcomed!
+1. **Install the plugin:** Build the project (see [Compiling](#compiling)), then copy the built plug-ins to your user or system plug-in folder:
+   - **VST3:** `~/Library/Audio/Plug-Ins/VST3/` (or `/Library/Audio/Plug-Ins/VST3/` for all users)
+   - **AU (Audio Unit):** `~/Library/Audio/Plug-Ins/Components/` (or `/Library/Audio/Plug-Ins/Components/` for all users)
+   Create the directory if it does not exist.
+
+2. **Use in hosts:**
+   - **Logic Pro:** Add the plugin to a channel (e.g. Audio FX → AU Effects → [manufacturer] → RNNoise).
+   - **Reaper:** Add FX to a track → VST3 or AU → RNNoise.
+   - **OBS:** In OBS, add a filter to your microphone source: **Audio Capture** or use a virtual device that receives processed audio from a host (e.g. Reaper) via a loopback or aggregate device.
+
+3. **Apple Silicon (M1/M2/M3):** The plugin is built as a native ARM binary when you compile on Apple Silicon. Intel (x86) builds run under Rosetta 2 if needed. Use a native ARM build for best performance.
 
 ## Status
 
@@ -206,6 +222,16 @@ External dependencies are vendored via [git-subrepo](https://github.com/ingydotn
 Improvements are welcomed! Though if you want to contribute anything sizeable - open an issue first.
 
 ### Compiling
+
+**Linux (Ubuntu / Linux Mint / Debian):** Install build dependencies so JUCE and the plugins can compile (e.g. juceaide needs freetype and X11). Example:
+
+```sh
+sudo apt-get install -y build-essential cmake ninja-build
+sudo apt-get install -y libfreetype6-dev libx11-dev libxrandr-dev libxcursor-dev libxinerama-dev libcurl4-openssl-dev
+sudo apt-get install -y libasound2-dev libgtk-3-dev libwebkit2gtk-4.1-dev
+```
+
+On older distros you may need `libwebkit2gtk-4.0-dev` instead of `libwebkit2gtk-4.1-dev`. If the build reports a missing header (e.g. `ft2build.h`, `X11/extensions/Xrandr.h`), install the corresponding `-dev` package.
 
 Compiling for x64:
 ```sh

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -33,8 +33,11 @@ if (BUILD_TESTS)
             $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/external/catch2>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
     target_link_libraries(common_plugin_tests PRIVATE ${LIBRARIES})
-    target_compile_options(common_plugin_tests PRIVATE -fsanitize=undefined)
-    target_link_options(common_plugin_tests PRIVATE -fsanitize=undefined)
+    # UBSan only in Debug so Release builds are never instrumented
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+        target_compile_options(common_plugin_tests PRIVATE -fsanitize=undefined)
+        target_link_options(common_plugin_tests PRIVATE -fsanitize=undefined)
+    endif()
 
     include(CTest)
     include(Catch)

--- a/src/juce_plugin/RnNoiseAudioProcessor.cpp
+++ b/src/juce_plugin/RnNoiseAudioProcessor.cpp
@@ -14,7 +14,7 @@ RnNoiseAudioProcessor::RnNoiseAudioProcessor()
                                                                     "VAD Threshold",
                                                                     0.0f,
                                                                     1.0f,
-                                                                    0.6f),
+                                                                    0.85f),
                         std::make_unique<juce::AudioParameterInt>("vad_grace_period",
                                                                   "VAD Grace Period (10ms per unit)",
                                                                   0,
@@ -24,12 +24,18 @@ RnNoiseAudioProcessor::RnNoiseAudioProcessor()
                                                                   "Retroactive VAD Grace Period (10ms per unit)",
                                                                   0,
                                                                   10,
-                                                                  0)
+                                                                  0),
+                        std::make_unique<juce::AudioParameterFloat>("mix",
+                                                                    "Mix",
+                                                                    0.0f,
+                                                                    1.0f,
+                                                                    1.0f)
                 }) {
     m_vadThresholdParam = (juce::AudioParameterFloat *) m_parameters.getParameter("vad_threshold");
     m_vadGracePeriodParam = (juce::AudioParameterInt *) m_parameters.getParameter("vad_grace_period");
     m_vadRetroactiveGracePeriodParam = (juce::AudioParameterInt *) m_parameters.getParameter(
             "vad_retroactive_grace_period");
+    m_mixParam = (juce::AudioParameterFloat *) m_parameters.getParameter("mix");
 }
 
 RnNoiseAudioProcessor::~RnNoiseAudioProcessor() = default;
@@ -105,15 +111,10 @@ void RnNoiseAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
 
     auto totalNumInputChannels = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();
+    auto numSamples = buffer.getNumSamples();
 
-    // In case we have more outputs than inputs, this code clears any output
-    // channels that didn't contain input data, (because these aren't
-    // guaranteed to be empty - they may contain garbage).
-    // This is here to avoid people getting screaming feedback
-    // when they first compile a plugin, but obviously you don't need to keep
-    // this code if your algorithm always overwrites all the output channels.
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
-        buffer.clear(i, 0, buffer.getNumSamples());
+        buffer.clear(i, 0, numSamples);
 
     const float *in[8] = {nullptr};
     float *out[8] = {nullptr};
@@ -122,9 +123,23 @@ void RnNoiseAudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         out[channel] = buffer.getWritePointer(channel);
     }
 
-    m_rnNoisePlugin->process(in, out, static_cast<size_t>(buffer.getNumSamples()), m_vadThresholdParam->get(),
+    const float mix = m_mixParam->get();
+    juce::AudioBuffer<float> dryCopy;
+    if (mix < 1.0f) {
+        dryCopy.makeCopyOf(buffer);
+    }
+
+    m_rnNoisePlugin->process(in, out, static_cast<size_t>(numSamples), m_vadThresholdParam->get(),
                              static_cast<uint32_t>(m_vadGracePeriodParam->get()),
                              static_cast<uint32_t>(m_vadRetroactiveGracePeriodParam->get()));
+
+    // Dry/wet mix: output = dry * (1 - mix) + wet * mix
+    if (mix < 1.0f && dryCopy.getNumSamples() > 0) {
+        for (int ch = 0; ch < totalNumInputChannels; ++ch) {
+            buffer.applyGain(ch, 0, numSamples, mix);
+            buffer.addFrom(ch, 0, dryCopy, ch, 0, numSamples, 1.0f - mix);
+        }
+    }
 }
 
 //==============================================================================

--- a/src/juce_plugin/RnNoiseAudioProcessor.h
+++ b/src/juce_plugin/RnNoiseAudioProcessor.h
@@ -51,6 +51,7 @@ public:
     juce::AudioParameterFloat* m_vadThresholdParam;
     juce::AudioParameterInt* m_vadGracePeriodParam;
     juce::AudioParameterInt* m_vadRetroactiveGracePeriodParam;
+    juce::AudioParameterFloat* m_mixParam;
 
     std::shared_ptr<RnNoiseCommonPlugin> m_rnNoisePlugin;
 

--- a/src/juce_plugin/RnNoisePluginEditor.cpp
+++ b/src/juce_plugin/RnNoisePluginEditor.cpp
@@ -41,6 +41,12 @@ RnNoiseAudioProcessorEditor::RnNoiseAudioProcessorEditor(RnNoiseAudioProcessor &
                                                                                vadRetroactiveGracePeriodParam->getParameterID(),
                                                                                m_vadRetroactiveGracePeriodSlider);
 
+    auto mixParam = m_processorRef.m_parameters.getParameter("mix");
+    m_mixLabel.setText(mixParam->getName(99), juce::dontSendNotification);
+    addAndMakeVisible(m_mixLabel);
+    addAndMakeVisible(m_mixSlider);
+    m_mixAttachment = std::make_unique<SliderAttachment>(m_valueTreeState, mixParam->getParameterID(), m_mixSlider);
+
     addAndMakeVisible(m_statsHeaderLabel);
     m_statsHeaderLabel.setText("Debug Statistics (updated once per second)", juce::dontSendNotification);
     m_statsHeaderLabel.setFont(juce::Font(20.0f, juce::Font::bold));
@@ -51,7 +57,7 @@ RnNoiseAudioProcessorEditor::RnNoiseAudioProcessorEditor(RnNoiseAudioProcessor &
     addAndMakeVisible(m_statsBlocksWaitingForOutputLabel);
     addAndMakeVisible(m_statsOutputFramesForcedToBeZeroedLabel);
 
-    setSize(400, 400);
+    setSize(400, 440);
 }
 
 void RnNoiseAudioProcessorEditor::paint(juce::Graphics &g) {
@@ -77,6 +83,8 @@ void RnNoiseAudioProcessorEditor::resized() {
             juce::FlexItem(m_vadRetroactiveGracePeriodLabel).withWidth(width).withFlex(1.0));
     flexBox.items.add(
             juce::FlexItem(m_vadRetroactiveGracePeriodSlider).withWidth(width).withFlex(1.0));
+    flexBox.items.add(juce::FlexItem(m_mixLabel).withWidth(width).withFlex(1.0));
+    flexBox.items.add(juce::FlexItem(m_mixSlider).withWidth(width).withFlex(1.0));
 
     flexBox.items.add(
             juce::FlexItem(m_statsHeaderLabel).withWidth(width).withFlex(1.0));

--- a/src/juce_plugin/RnNoisePluginEditor.h
+++ b/src/juce_plugin/RnNoisePluginEditor.h
@@ -37,6 +37,10 @@ private:
     juce::Slider m_vadRetroactiveGracePeriodSlider;
     std::unique_ptr<SliderAttachment> m_vadRetroactiveGracePeriodAttachment;
 
+    juce::Label m_mixLabel;
+    juce::Slider m_mixSlider;
+    std::unique_ptr<SliderAttachment> m_mixAttachment;
+
     juce::Label m_statsHeaderLabel;
     juce::Label m_statsVadGraceBlocksLabel;
     juce::Label m_statsRetroactiveVadGraceBlocksLabel;

--- a/src/ladspa_plugin/RnNoiseLadspaPlugin.h
+++ b/src/ladspa_plugin/RnNoiseLadspaPlugin.h
@@ -39,11 +39,26 @@ namespace port_info_custom {
                     200.f
             }
     };
-    constexpr static port_info_t placeholder_input = {
-            "Placeholder",
-            "Currently unused.",
+    constexpr static port_info_t vad_threshold_alt_input = {
+            "VAD Threshold (%)",
+            "Voice activity detection threshold (0-100). Recommended default: 85.",
             port_types::input | port_types::control,
-            {0, 0.f, 0.f}
+            {
+                    port_hints::bounded_below | port_hints::bounded_above | port_hints::integer |
+                    port_hints::default_middle,
+                    0.f,
+                    100.f
+            }
+    };
+    constexpr static port_info_t mix_input = {
+            "Mix",
+            "Dry/wet mix (0 = dry only, 1 = full wet). Default: 1.",
+            port_types::input | port_types::control,
+            {
+                    port_hints::bounded_below | port_hints::bounded_above | port_hints::default_maximum,
+                    0.f,
+                    1.f
+            }
     };
 }
 
@@ -66,8 +81,8 @@ struct RnNoiseMono {
                     port_info_custom::vad_threshold_input,
                     port_info_custom::vad_grace_period_blocks_input,
                     port_info_custom::retroactive_vad_grace_blocks_input,
-                    port_info_custom::placeholder_input,
-                    port_info_custom::placeholder_input,
+                    port_info_custom::vad_threshold_alt_input,
+                    port_info_custom::mix_input,
                     port_info_common::final_port
             };
 
@@ -101,6 +116,7 @@ struct RnNoiseMono {
         uint32_t vad_threshold = ports.get<port_names::in_vad_threshold>();
         uint32_t vad_grace_period_blocks = ports.get<port_names::in_vad_grace_period_blocks>() / ms_in_block;
         uint32_t retroactive_vad_grace_blocks = ports.get<port_names::in_retroactive_vad_grace_blocks>() / ms_in_block;
+        float mix = std::max(std::min(ports.get<port_names::in_placeholder2>(), 1.f), 0.f);
 
         float vad_threshold_normalized = std::max(std::min(vad_threshold / 100.f, 0.99f), 0.f);
 
@@ -109,6 +125,12 @@ struct RnNoiseMono {
 
         m_rnNoisePlugin->process(input, output, in_buffer.size(), vad_threshold_normalized,
                                  vad_grace_period_blocks, retroactive_vad_grace_blocks);
+
+        if (mix < 1.f) {
+            const float dryGain = 1.f - mix;
+            for (size_t i = 0; i < in_buffer.size(); ++i)
+                out_buffer.data()[i] = in_buffer.data()[i] * dryGain + out_buffer.data()[i] * mix;
+        }
     }
 
     std::unique_ptr<RnNoiseCommonPlugin> m_rnNoisePlugin;
@@ -137,8 +159,8 @@ struct RnNoiseStereo {
                     port_info_custom::vad_threshold_input,
                     port_info_custom::vad_grace_period_blocks_input,
                     port_info_custom::retroactive_vad_grace_blocks_input,
-                    port_info_custom::placeholder_input,
-                    port_info_custom::placeholder_input,
+                    port_info_custom::vad_threshold_alt_input,
+                    port_info_custom::mix_input,
                     port_info_common::final_port
             };
 
@@ -176,6 +198,7 @@ struct RnNoiseStereo {
         uint32_t vad_threshold = ports.get<port_names::in_vad_threshold>();
         uint32_t vad_grace_period_blocks = ports.get<port_names::in_vad_grace_period_blocks>() / ms_in_block;
         uint32_t retroactive_vad_grace_blocks = ports.get<port_names::in_retroactive_vad_grace_blocks>() / ms_in_block;
+        float mix = std::max(std::min(ports.get<port_names::in_placeholder2>(), 1.f), 0.f);
 
         float vad_threshold_normalized = std::max(std::min(vad_threshold / 100.f, 0.99f), 0.f);
 
@@ -184,6 +207,14 @@ struct RnNoiseStereo {
 
         m_rnNoisePlugin->process(input, output, in_buffer_l.size(), vad_threshold_normalized,
                                  vad_grace_period_blocks, retroactive_vad_grace_blocks);
+
+        if (mix < 1.f) {
+            const float dryGain = 1.f - mix;
+            for (size_t i = 0; i < in_buffer_l.size(); ++i) {
+                out_buffer_l.data()[i] = in_buffer_l.data()[i] * dryGain + out_buffer_l.data()[i] * mix;
+                out_buffer_r.data()[i] = in_buffer_r.data()[i] * dryGain + out_buffer_r.data()[i] * mix;
+            }
+        }
     }
 
     std::unique_ptr<RnNoiseCommonPlugin> m_rnNoisePlugin;


### PR DESCRIPTION
## Summary

This PR batches documentation fixes, build improvements, the dry/wet mix feature, and LADSPA port repurposing.

### Documentation
- **Fixes #199** — VAD threshold consistency: recommend 85% as default, document valid range 0–100%, and use 85 in README/config snippets (PipeWire, PulseAudio).
- **Fixes #195** — Equalizer APO: add current download link (https://equalizerapo.com/) and SourceForge.
- **Fixes #212** — Windows + Equalizer APO: clearer, numbered installation steps for Windows 10/11.
- **Fixes #232** — macOS: add installation section (VST3/AU paths, Logic Pro, Reaper, OBS, Apple Silicon note).
- **Fixes #225** — Linux: add required apt packages for Ubuntu/Linux Mint/Debian (e.g. `libfreetype6-dev`, `libx11-dev`, `libxrandr-dev`, `libwebkit2gtk-4.1-dev`) so JUCE/juceaide builds.

### Build
- **Fixes #219, #189** — CMake: add option `ENABLE_NATIVE_OPTIMIZATIONS` (default ON) with `-O3` and `-march=native` for Release (GCC/Clang), optional SSE2 on x86. Restrict `-fsanitize=undefined` to Debug builds only (test target). Add CMP0048 and default `JUCE_SOURCE_DIR` when not set.

### Feature: Dry/wet mix
- **Fixes #228, #211, #182** — JUCE plugin: add “Mix” parameter (0.0–1.0, default 1.0). Blend: `output = dry * (1 - mix) + wet * mix`. UI slider and state save/restore included.

### LADSPA
- **Fixes #186** — Repurpose placeholder ports: “Placeholder 1” → “VAD Threshold (%)” (0–100, default 85), “Placeholder 2” → “Mix” (0–1, default 1). Implement mix blending in mono and stereo LADSPA run(). Port count and indices unchanged.

### Notes
- Issue **#177** (VST3 with JUCE 7.0.6): default `JUCE_SOURCE_DIR` to `external/JUCE` when unset so the project configures without extra flags; no code change for JUCE 7 API.
- All changes are backward‑friendly: existing PulseAudio configs keep working (5th control now Mix; 1 = full wet).